### PR TITLE
Add possibility to specify OpenVPN device number when generating container config

### DIFF
--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -102,6 +102,7 @@ usage() {
     echo " -m    Set client MTU"
     echo " -N    Configure NAT to access external server network"
     echo " -t    Use TAP device (instead of TUN device)"
+    echo " -o    Set the OpenVPN device number, e.g. pass 1 to create interface tun1. Default: 0"
     echo " -T    Encrypt packets with the given cipher algorithm instead of the default one (tls-cipher)."
     echo " -z    Enable comp-lzo compression."
     echo " -B    Start a network bridge for TAP mode and use \"server-bridge\" directive in OpenVPN server config;"

--- a/bin/ovpn_genconfig
+++ b/bin/ovpn_genconfig
@@ -196,7 +196,7 @@ OVPN_BR_DHCP_END=''
 [ -r "$OVPN_ENV" ] && source "$OVPN_ENV"
 
 # Parse arguments
-PARSED_ARGUMENTS=$(getopt -l "bridge-name:,bridge-eth-if:,bridge-eth-ip:,bridge-eth-subnet:,bridge-eth-broadcast:,bridge-eth-gateway:,bridge-eth-mac:,bridge-dhcp-start:,bridge-dhcp-end:" -o ":a:e:E:C:T:r:s:du:bcp:n:k:DNm:f:tz2B" -- "$@")
+PARSED_ARGUMENTS=$(getopt -l "bridge-name:,bridge-eth-if:,bridge-eth-ip:,bridge-eth-subnet:,bridge-eth-broadcast:,bridge-eth-gateway:,bridge-eth-mac:,bridge-dhcp-start:,bridge-dhcp-end:" -o ":a:e:E:C:T:r:s:du:bcp:n:k:DNm:f:o:tz2B" -- "$@")
 VALID_ARGUMENTS=$?
 if [ "$VALID_ARGUMENTS" != "0" ]; then
   usage
@@ -288,6 +288,10 @@ do
             ;;
         -t)
             OVPN_DEVICE="tap"
+            ;;
+        -o)
+            shift
+            OVPN_DEVICEN="$1"
             ;;
         -z)
             OVPN_COMP_LZO=1


### PR DESCRIPTION
Makes it possible to pass `-o <interfaceSuffix>` to `ovpn_genconfig` to define the suffix used when creating the OpenVPN device, e.g. `-o 1` will create `tun1` instead of `tun0`.