### PR TITLE
Enhancement: Respect existing bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ nmcli device set eth0 managed no
     ```
     ⚠️ __Caution__: Choosing the wrong bridge argument values may render your host machine unreachable over the network! Make sure to have direct access or choose wisely!
 
+    If a bridge with the provided name already exists, the container will simply use that. If the host network interface (`--bridge-eth-if`) is already part of that bridge, the container will leave the bridge alone on startup and shutdown. In that case, the following arguments do not have any effect:
+      - `--bridge-eth-subnet`
+      - `--bridge-eth-broadcast`
+      - `--bridge-eth-gatewayt`
+      - `--bridge-eth-mac`
+
   * Create certificates for generating clients:
     ```bash
     docker run -v $OVPN_DATA:/etc/openvpn --rm -it salvoxia/openvpn-tap ovpn_initpki

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -70,30 +70,14 @@ if [ $OVPN_DEVICE == "tap" ]; then
     
     ip link set $OVPN_DEVICE$OVPN_DEVICEN up
     echo 'Setting up bridge'
-    BRIDGE_EXISTS=$(ip link show | grep -c $OVPN_BR_BR:)
     # check if bridge already exists; create if not
-    if [ $BRIDGE_EXISTS -eq 0 ]; then
+    if [ $(ip link show | grep -c $OVPN_BR_BR:) -eq 0 ]; then
         brctl addbr $OVPN_BR_BR
 
         echo 'setting IP, subnet and broadcast address for bridge'
         ifconfig $OVPN_BR_BR $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
-        
-        # Add default route if eth is also gateway port
         echo 'setting mac address for bridge'
         ip link set $OVPN_BR_BR address $OVPN_BR_ETH_MAC
-
-        echo 'checking if default gateway needs to be added for bridge'
-        if [ $(route | grep -c -Eo "^default\s+$OVPN_BR_ETH_GATEWAY.+$OVPN_BR_BR$") -eq 0 ]; then
-            route add default gw $OVPN_BR_ETH_GATEWAY $OVPN_BR_BR
-        fi
-
-        echo 'setting up IPTABLES for bridge device'
-        if [ $($IPTABLES_CMD -S | grep -c -- "-A INPUT -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
-            $IPTABLES_CMD -A INPUT -i $OVPN_BR_BR -j ACCEPT
-        fi
-        if [ $($IPTABLES_CMD -S | grep -c -- "-A FORWARD -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
-            $IPTABLES_CMD -A FORWARD -i $OVPN_BR_BR -j ACCEPT
-        fi
     else
         # Remember the bridge alread existed at startup
         touch /tmp/bridge_existed
@@ -102,9 +86,6 @@ if [ $OVPN_DEVICE == "tap" ]; then
     # check if $OVPN_BR_ETH_IF is already added to bridge; add if not
     if [ $(brctl show $OVPN_BR_BR | grep -c $OVPN_BR_ETH_IF) -eq 0 ]; then
         brctl addif $OVPN_BR_BR $OVPN_BR_ETH_IF
-
-        echo 'setting eth device to promiscous mode'
-        ifconfig $OVPN_BR_ETH_IF 0.0.0.0 promisc up
     else
         # Remember the interface was already part of the bridge at startup
         touch /tmp/if_belonged_to_bridge
@@ -117,14 +98,27 @@ if [ $OVPN_DEVICE == "tap" ]; then
     
     echo 'setting tap device to promiscous mode'
     ifconfig $OVPN_DEVICE$OVPN_DEVICEN 0.0.0.0 promisc up
+    echo 'setting eth device to promiscous mode'
+    ifconfig $OVPN_BR_ETH_IF 0.0.0.0 promisc up
+
+    # Add default route if eth is also gateway port
+    echo 'checking if default gateway needs to be added for bridge'
+    if [ $(route | grep -c -Eo "^default\s+$OVPN_BR_ETH_GATEWAY.+$OVPN_BR_BR$") -eq 0 ]; then
+        route add default gw $OVPN_BR_ETH_GATEWAY $OVPN_BR_BR
+    fi
     
-    echo 'setting up IPTABLES for tap device'
+    echo 'setting up IPTABLES'
     # check if entry already exists before adding
     if [ $($IPTABLES_CMD -S | grep -c -- "-A INPUT -i $OVPN_DEVICE$OVPN_DEVICEN -j ACCEPT") -eq 0 ]; then
        
        $IPTABLES_CMD -A INPUT -i $OVPN_DEVICE$OVPN_DEVICEN -j ACCEPT
     fi
-
+    if [ $($IPTABLES_CMD -S | grep -c -- "-A INPUT -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
+        $IPTABLES_CMD -A INPUT -i $OVPN_BR_BR -j ACCEPT
+    fi
+    if [ $($IPTABLES_CMD -S | grep -c -- "-A FORWARD -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
+        $IPTABLES_CMD -A FORWARD -i $OVPN_BR_BR -j ACCEPT
+    fi
 fi
 
 if [ -d "$OPENVPN/ccd" ]; then

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -198,7 +198,7 @@ cleanup()
         
         echo 'Stopping OpenVPN'
         killall openvpn
-        
+        sleep 6
         echo 'Removing iptables rules'
         if [ -z "$(grep "br input role exists" /tmp/initial_situation)" ]; then
             echo "Removing bridge INPUT rule"
@@ -206,7 +206,7 @@ cleanup()
         fi
         
         if [ -z "$(grep "br forward role exists" /tmp/initial_situation)" ]; then
-            echo "Removing bridge INPUT rule"
+            echo "Removing bridge FORWARD rule"
             $IPTABLES_CMD -D FORWARD -i $OVPN_BR_BR -j ACCEPT
         fi
         

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -200,7 +200,7 @@ cleanup()
         OVPN_PID=$(pgrep openvpn)
         killall openvpn
         # Wait for shutdown complete
-        while kill -0 $OVPN_PID; do
+        while $(kill -0 $PID 2>/dev/null); do
             sleep 1
         done
         

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -200,7 +200,7 @@ cleanup()
         OVPN_PID=$(pgrep openvpn)
         killall openvpn
         # Wait for shutdown complete
-        while $(kill -0 $PID 2>/dev/null); do
+        while $(kill -0 $OVPN_PID 2>/dev/null); do
             sleep 1
         done
         

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -200,18 +200,18 @@ cleanup()
         killall openvpn
         
         echo 'Removing iptables rules'
-        if [ $(grep "br input role exists" /tmp/initial_situation) -eq 0 ]; then
+        if [ -z "$(grep "br input role exists" /tmp/initial_situation)" ]; then
             echo "Removing bridge INPUT rule"
             $IPTABLES_CMD -D INPUT -i $OVPN_BR_BR -j ACCEPT
         fi
         
-        if [ $(grep "br forward role exists" /tmp/initial_situation) -eq 0 ]; then
+        if [ -z "$(grep "br forward role exists" /tmp/initial_situation)" ]; then
             echo "Removing bridge INPUT rule"
             $IPTABLES_CMD -D FORWARD -i $OVPN_BR_BR -j ACCEPT
         fi
         
         # Remove physical interface from the bridge if it did not belong to the bridge at startup
-        if [ $(grep "if belongs to bridge" /tmp/initial_situation) -eq 0 ]; then
+        if [ -z "$(grep "if belongs to bridge" /tmp/initial_situation)" ]; then
             # Remove eth device from bridge
             brctl delif $OVPN_BR_BR $OVPN_BR_ETH_IF
         fi
@@ -220,7 +220,7 @@ cleanup()
         # Remove OpenVPN device from bridge
         brctl delif $OVPN_BR_BR $OVPN_DEVICE$OVPN_DEVICEN
 
-        if [ $(grep "bridge exists" /tmp/initial_situation) -eq 0 ]; then
+        if [ -z "$(grep "bridge exists" /tmp/initial_situation)" ]; then
             echo 'Shuttdown down bridge'
             ip link set $OVPN_BR_BR down
 
@@ -230,7 +230,7 @@ cleanup()
             fi
         fi
 
-        if [ $(grep "if belongs to bridge" /tmp/initial_situation) -eq 0 ]; then
+        if [ -z "$(grep "if belongs to bridge" /tmp/initial_situation)" ]; then
             echo 'setting IP, subnet and broadcast address for physical device'
             #ifconfig $OVPN_BR_ETH_IF $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
             OVPN_BR_CIDR=$(mask2cidr $OVPN_BR_ETH_SUBNET)

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -198,8 +198,10 @@ cleanup()
         
         echo 'Stopping OpenVPN'
         killall openvpn
-        sleep 6
-        echo 'Removing iptables rules'
+        while kill -0 $(pgrep openvpn); do
+            sleep 1
+        done
+        
         if [ -z "$(grep "br input role exists" /tmp/initial_situation)" ]; then
             echo "Removing bridge INPUT rule"
             $IPTABLES_CMD -D INPUT -i $OVPN_BR_BR -j ACCEPT

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -197,8 +197,10 @@ cleanup()
         
         
         echo 'Stopping OpenVPN'
+        OVPN_PID=$(pgrep openvpn)
         killall openvpn
-        while kill -0 $(pgrep openvpn); do
+        # Wait for shutdown complete
+        while kill -0 $OVPN_PID; do
             sleep 1
         done
         

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -70,9 +70,30 @@ if [ $OVPN_DEVICE == "tap" ]; then
     
     ip link set $OVPN_DEVICE$OVPN_DEVICEN up
     echo 'Setting up bridge'
+    BRIDGE_EXISTS=$(ip link show | grep -c $OVPN_BR_BR:)
     # check if bridge already exists; create if not
-    if [ $(ip link show | grep -c $OVPN_BR_BR:) -eq 0 ]; then
+    if [ $BRIDGE_EXISTS -eq 0 ]; then
         brctl addbr $OVPN_BR_BR
+
+        echo 'setting IP, subnet and broadcast address for bridge'
+        ifconfig $OVPN_BR_BR $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
+        
+        # Add default route if eth is also gateway port
+        echo 'setting mac address for bridge'
+        ip link set $OVPN_BR_BR address $OVPN_BR_ETH_MAC
+
+        echo 'checking if default gateway needs to be added for bridge'
+        if [ $(route | grep -c -Eo "^default\s+$OVPN_BR_ETH_GATEWAY.+$OVPN_BR_BR$") -eq 0 ]; then
+            route add default gw $OVPN_BR_ETH_GATEWAY $OVPN_BR_BR
+        fi
+
+        echo 'setting up IPTABLES for bridge device'
+        if [ $($IPTABLES_CMD -S | grep -c -- "-A INPUT -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
+            $IPTABLES_CMD -A INPUT -i $OVPN_BR_BR -j ACCEPT
+        fi
+        if [ $($IPTABLES_CMD -S | grep -c -- "-A FORWARD -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
+            $IPTABLES_CMD -A FORWARD -i $OVPN_BR_BR -j ACCEPT
+        fi
     else
         # Remember the bridge alread existed at startup
         touch /tmp/bridge_existed
@@ -81,6 +102,9 @@ if [ $OVPN_DEVICE == "tap" ]; then
     # check if $OVPN_BR_ETH_IF is already added to bridge; add if not
     if [ $(brctl show $OVPN_BR_BR | grep -c $OVPN_BR_ETH_IF) -eq 0 ]; then
         brctl addif $OVPN_BR_BR $OVPN_BR_ETH_IF
+
+        echo 'setting eth device to promiscous mode'
+        ifconfig $OVPN_BR_ETH_IF 0.0.0.0 promisc up
     else
         # Remember the interface was already part of the bridge at startup
         touch /tmp/if_belonged_to_bridge
@@ -93,32 +117,14 @@ if [ $OVPN_DEVICE == "tap" ]; then
     
     echo 'setting tap device to promiscous mode'
     ifconfig $OVPN_DEVICE$OVPN_DEVICEN 0.0.0.0 promisc up
-    echo 'setting eth device to promiscous mode'
-    ifconfig $OVPN_BR_ETH_IF 0.0.0.0 promisc up
-    echo 'setting IP, subnet and broadcast address for bridge'
-    ifconfig $OVPN_BR_BR $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
     
-    # Add default route if eth is also gateway port
-    echo 'setting mac address for bridge'
-    ip link set $OVPN_BR_BR address $OVPN_BR_ETH_MAC
-    
-    echo 'checking if default gateway needs to be added for bridge'
-    if [ $(route | grep -c -Eo "^default\s+$OVPN_BR_ETH_GATEWAY.+$OVPN_BR_BR$") -eq 0 ]; then
-        route add default gw $OVPN_BR_ETH_GATEWAY $OVPN_BR_BR
-    fi
-    
-    echo 'setting up IPTABLES'
+    echo 'setting up IPTABLES for tap device'
     # check if entry already exists before adding
     if [ $($IPTABLES_CMD -S | grep -c -- "-A INPUT -i $OVPN_DEVICE$OVPN_DEVICEN -j ACCEPT") -eq 0 ]; then
        
        $IPTABLES_CMD -A INPUT -i $OVPN_DEVICE$OVPN_DEVICEN -j ACCEPT
     fi
-    if [ $($IPTABLES_CMD -S | grep -c -- "-A INPUT -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
-        $IPTABLES_CMD -A INPUT -i $OVPN_BR_BR -j ACCEPT
-    fi
-    if [ $($IPTABLES_CMD -S | grep -c -- "-A FORWARD -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
-        $IPTABLES_CMD -A FORWARD -i $OVPN_BR_BR -j ACCEPT
-    fi
+
 fi
 
 if [ -d "$OPENVPN/ccd" ]; then
@@ -167,7 +173,7 @@ fi
 cleanup() 
 {
     if [ $OVPN_DEVICE == "tap" ]; then
-        echo 'Tearing down bridge...'
+        
         
         echo 'Stopping OpenVPN'
         killall openvpn
@@ -180,10 +186,12 @@ cleanup()
         if test -f "/tmp/if_belonged_to_bridge"; then
             rm /tmp/if_belonged_to_bridge
             # Nothing to do in terms of bridge management
+            echo 'Leaving bridge alone, it already existed at startup'
         else
+            echo 'Removing interfaces from bridge'
             # Remove eth device from bridge
             brctl delif $OVPN_BR_BR $OVPN_BR_ETH_IF
-
+            
             # Remove OpenVPN device from bridge
             brctl delif $OVPN_BR_BR $OVPN_DEVICE$OVPN_DEVICEN
 

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -73,11 +73,17 @@ if [ $OVPN_DEVICE == "tap" ]; then
     # check if bridge already exists; create if not
     if [ $(ip link show | grep -c $OVPN_BR_BR:) -eq 0 ]; then
         brctl addbr $OVPN_BR_BR
+    else
+        # Remember the bridge alread existed at startup
+        touch /tmp/bridge_existed
     fi
     
     # check if $OVPN_BR_ETH_IF is already added to bridge; add if not
     if [ $(brctl show $OVPN_BR_BR | grep -c $OVPN_BR_ETH_IF) -eq 0 ]; then
         brctl addif $OVPN_BR_BR $OVPN_BR_ETH_IF
+    else
+        # Remember the interface was already part of the bridge at startup
+        touch /tmp/if_belonged_to_bridge
     fi
     
     # check if openvpn device is already added to bridge; add if not
@@ -169,16 +175,40 @@ cleanup()
         echo 'Removing iptables rules'
         $IPTABLES_CMD -D INPUT -i $OVPN_BR_BR -j ACCEPT
         $IPTABLES_CMD -D FORWARD -i $OVPN_BR_BR -j ACCEPT
-
-        echo 'Shuttdown down bridge'
-        ifconfig $OVPN_BR_BR down
-
-        echo 'Deleting bridge'
-        # check if bridge already exists; create if not
-        if [ $(ip link show | grep -c $OVPN_BR_BR:) -eq 1 ]; then
-            brctl delbr $OVPN_BR_BR
-        fi
         
+        # This means that the bridge already existed and our interface to bridge
+        if test -f "/tmp/if_belonged_to_bridge"; then
+            rm /tmp/if_belonged_to_bridge
+            # Nothing to do in terms of bridge management
+        else
+            # Remove eth device from bridge
+            brctl delif $OVPN_BR_BR $OVPN_BR_ETH_IF
+
+            # Remove OpenVPN device from bridge
+            brctl delif $OVPN_BR_BR $OVPN_DEVICE$OVPN_DEVICEN
+
+            if test -f "/tmp/bridge_existed"; then
+                rm /tmp/bridge_existed
+
+                echo 'Shuttdown down bridge'
+                ifconfig $OVPN_BR_BR down
+
+                echo 'Deleting bridge'
+                # check if bridge already exists; create if not
+                if [ $(ip link show | grep -c $OVPN_BR_BR:) -eq 1 ]; then
+                    brctl delbr $OVPN_BR_BR
+                fi
+            fi
+
+            echo 'setting IP, subnet and broadcast address for physical device'
+            ifconfig $OVPN_BR_ETH_IF $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
+
+            echo 'checking if default gateway needs to be added for pyhsical device'
+            if [ $(route | grep -c -Eo "^default\s+$OVPN_BR_ETH_GATEWAY.+$OVPN_BR_ETH_IF$") -eq 0 ]; then
+                route add default gw $OVPN_BR_ETH_GATEWAY $OVPN_BR_ETH_IF
+            fi
+        fi
+
         echo 'Removing tap device'
         if [ $(ip link show | grep -c $OVPN_DEVICE$OVPN_DEVICEN:) -eq 1 ]; then
             ifconfig $OVPN_DEVICE$OVPN_DEVICEN down
@@ -186,14 +216,6 @@ cleanup()
         fi
         
         $IPTABLES_CMD -D INPUT -i $OVPN_DEVICE$OVPN_DEVICEN -j ACCEPT
-
-        echo 'setting IP, subnet and broadcast address for physical device'
-        ifconfig $OVPN_BR_ETH_IF $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
-
-        echo 'checking if default gateway needs to be added for pyhsical device'
-        if [ $(route | grep -c -Eo "^default\s+$OVPN_BR_ETH_GATEWAY.+$OVPN_BR_ETH_IF$") -eq 0 ]; then
-            route add default gw $OVPN_BR_ETH_GATEWAY $OVPN_BR_ETH_IF
-        fi
     fi
 }
 

--- a/bin/ovpn_run
+++ b/bin/ovpn_run
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+mask2cdr ()
+{
+   # Assumes there's no "255." after a non-255 byte in the mask
+   local x=${1##*255.}
+   set -- 0^^^128^192^224^240^248^252^254^ $(( (${#1} - ${#x})*2 )) ${x%%.*}
+   x=${1%%$3*}
+   echo $(( $2 + (${#x}/4) ))
+}
+
 #
 # Run the OpenVPN server normally
 #
@@ -65,22 +74,28 @@ fi
 
 if [ $OVPN_DEVICE == "tap" ]; then
     if [ $(ip link show | grep -c $OVPN_DEVICE$OVPN_DEVICEN:) -eq 0 ]; then
-            openvpn --mktun --dev $OVPN_DEVICE$OVPN_DEVICEN
+        openvpn --mktun --dev $OVPN_DEVICE$OVPN_DEVICEN
     fi
     
     ip link set $OVPN_DEVICE$OVPN_DEVICEN up
     echo 'Setting up bridge'
+    # clear initial situation
+    echo "" > /tmp/initial_situation
     # check if bridge already exists; create if not
     if [ $(ip link show | grep -c $OVPN_BR_BR:) -eq 0 ]; then
         brctl addbr $OVPN_BR_BR
 
         echo 'setting IP, subnet and broadcast address for bridge'
-        ifconfig $OVPN_BR_BR $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
+        OVPN_BR_CIDR=$(mask2cidr $OVPN_BR_ETH_SUBNET)
+        ip addr add $OVPN_BR_ETH_IP/$OVPN_BR_CIDR dev $OVPN_BR_BR
+        ip addr add broadcast $OVPN_BR_ETH_BROADCAST dev $OVPN_BR_BR
+
         echo 'setting mac address for bridge'
         ip link set $OVPN_BR_BR address $OVPN_BR_ETH_MAC
     else
         # Remember the bridge alread existed at startup
-        touch /tmp/bridge_existed
+        echo "bridge exists" >> /tmp/initial_situation
+        echo "bridge $OVPN_BR_BR already exists"
     fi
     
     # check if $OVPN_BR_ETH_IF is already added to bridge; add if not
@@ -88,7 +103,8 @@ if [ $OVPN_DEVICE == "tap" ]; then
         brctl addif $OVPN_BR_BR $OVPN_BR_ETH_IF
     else
         # Remember the interface was already part of the bridge at startup
-        touch /tmp/if_belonged_to_bridge
+        echo "if belongs to bridge" >> /tmp/initial_situation
+        echo "interface $OVPN_BR_ETH_IF is already part of bridge $OVPN_BR_BR"
     fi
     
     # check if openvpn device is already added to bridge; add if not
@@ -96,10 +112,16 @@ if [ $OVPN_DEVICE == "tap" ]; then
         brctl addif $OVPN_BR_BR $OVPN_DEVICE$OVPN_DEVICEN
     fi
     
-    echo 'setting tap device to promiscous mode'
-    ifconfig $OVPN_DEVICE$OVPN_DEVICEN 0.0.0.0 promisc up
-    echo 'setting eth device to promiscous mode'
-    ifconfig $OVPN_BR_ETH_IF 0.0.0.0 promisc up
+    #echo 'setting tap device to promiscous mode'
+    #ifconfig $OVPN_DEVICE$OVPN_DEVICEN 0.0.0.0 promisc up
+    ## check if interface is already in promiscous mode
+    #if [ $(ip link show | grep "$OVPN_BR_ETH_IF:.*PROMISC.*") -eq 0 ]; then
+    #    echo 'setting eth device to promiscous mode'
+    #    ifconfig $OVPN_BR_ETH_IF 0.0.0.0 promisc up
+    #else
+    #    # Remember interface was already in promiscous mode
+    #    echo "if is promisc" >> /tmp/initial_situation
+    #fi
 
     # Add default route if eth is also gateway port
     echo 'checking if default gateway needs to be added for bridge'
@@ -115,9 +137,14 @@ if [ $OVPN_DEVICE == "tap" ]; then
     fi
     if [ $($IPTABLES_CMD -S | grep -c -- "-A INPUT -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
         $IPTABLES_CMD -A INPUT -i $OVPN_BR_BR -j ACCEPT
+    else
+        echo "br input role exists" >> /tmp/initial_situation
     fi
+
     if [ $($IPTABLES_CMD -S | grep -c -- "-A FORWARD -i $OVPN_BR_BR -j ACCEPT") -eq 0 ]; then
         $IPTABLES_CMD -A FORWARD -i $OVPN_BR_BR -j ACCEPT
+    else
+        echo "br forward role exists" >> /tmp/initial_situation
     fi
 fi
 
@@ -173,47 +200,52 @@ cleanup()
         killall openvpn
         
         echo 'Removing iptables rules'
-        $IPTABLES_CMD -D INPUT -i $OVPN_BR_BR -j ACCEPT
-        $IPTABLES_CMD -D FORWARD -i $OVPN_BR_BR -j ACCEPT
+        if [ $(grep "br input role exists" /tmp/initial_situation) -eq 0 ]; then
+            echo "Removing bridge INPUT rule"
+            $IPTABLES_CMD -D INPUT -i $OVPN_BR_BR -j ACCEPT
+        fi
         
-        # This means that the bridge already existed and our interface to bridge
-        if test -f "/tmp/if_belonged_to_bridge"; then
-            rm /tmp/if_belonged_to_bridge
-            # Nothing to do in terms of bridge management
-            echo 'Leaving bridge alone, it already existed at startup'
-        else
-            echo 'Removing interfaces from bridge'
+        if [ $(grep "br forward role exists" /tmp/initial_situation) -eq 0 ]; then
+            echo "Removing bridge INPUT rule"
+            $IPTABLES_CMD -D FORWARD -i $OVPN_BR_BR -j ACCEPT
+        fi
+        
+        # Remove physical interface from the bridge if it did not belong to the bridge at startup
+        if [ $(grep "if belongs to bridge" /tmp/initial_situation) -eq 0 ]; then
             # Remove eth device from bridge
             brctl delif $OVPN_BR_BR $OVPN_BR_ETH_IF
-            
-            # Remove OpenVPN device from bridge
-            brctl delif $OVPN_BR_BR $OVPN_DEVICE$OVPN_DEVICEN
+        fi
+        
+        echo 'Removing tap device from bridge'
+        # Remove OpenVPN device from bridge
+        brctl delif $OVPN_BR_BR $OVPN_DEVICE$OVPN_DEVICEN
 
-            if test -f "/tmp/bridge_existed"; then
-                rm /tmp/bridge_existed
+        if [ $(grep "bridge exists" /tmp/initial_situation) -eq 0 ]; then
+            echo 'Shuttdown down bridge'
+            ip link set $OVPN_BR_BR down
 
-                echo 'Shuttdown down bridge'
-                ifconfig $OVPN_BR_BR down
-
-                echo 'Deleting bridge'
-                # check if bridge already exists; create if not
-                if [ $(ip link show | grep -c $OVPN_BR_BR:) -eq 1 ]; then
-                    brctl delbr $OVPN_BR_BR
-                fi
+            echo 'Deleting bridge'
+            if [ $(ip link show | grep -c $OVPN_BR_BR:) -eq 1 ]; then
+                brctl delbr $OVPN_BR_BR
             fi
+        fi
 
+        if [ $(grep "if belongs to bridge" /tmp/initial_situation) -eq 0 ]; then
             echo 'setting IP, subnet and broadcast address for physical device'
-            ifconfig $OVPN_BR_ETH_IF $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
+            #ifconfig $OVPN_BR_ETH_IF $OVPN_BR_ETH_IP netmask $OVPN_BR_ETH_SUBNET broadcast $OVPN_BR_ETH_BROADCAST
+            OVPN_BR_CIDR=$(mask2cidr $OVPN_BR_ETH_SUBNET)
+            ip addr add $OVPN_BR_ETH_IP/$OVPN_BR_CIDR dev $OVPN_BR_ETH_IF
+            ip addr add broadcast $OVPN_BR_ETH_BROADCAST dev $OVPN_BR_ETH_IF
 
             echo 'checking if default gateway needs to be added for pyhsical device'
-            if [ $(route | grep -c -Eo "^default\s+$OVPN_BR_ETH_GATEWAY.+$OVPN_BR_ETH_IF$") -eq 0 ]; then
-                route add default gw $OVPN_BR_ETH_GATEWAY $OVPN_BR_ETH_IF
+            if [ $(ip route | grep -c "default via $OVPN_BR_ETH_GATEWAY dev $OVPN_BR_ETH_IF") -eq 0 ]; then
+                ip route add default via $OVPN_BR_ETH_GATEWAY dev $OVPN_BR_ETH_IF
             fi
         fi
 
         echo 'Removing tap device'
         if [ $(ip link show | grep -c $OVPN_DEVICE$OVPN_DEVICEN:) -eq 1 ]; then
-            ifconfig $OVPN_DEVICE$OVPN_DEVICEN down
+            ip link set $OVPN_DEVICE$OVPN_DEVICEN down
             openvpn --rmtun --dev $OVPN_DEVICE$OVPN_DEVICEN
         fi
         


### PR DESCRIPTION
  - If the network bridge to create already exists, the existing bridge will be used
  - If the network interface to bridge is already part of the bridge, it will not be touched
  - Enhanced shutdown sequence to
    - wait for OpenVPN to have shut down
    - only revert interface operations that were performed during startup
  - Updated bridge setup/shut down scripts to only is `ip` instead of deprecated `route` and `ifconfig` utilities